### PR TITLE
Logging configuration

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -529,7 +529,8 @@ to the original file in @product@:
       the
       [Log4j XML Configuration Primer](https://wiki.apache.org/logging-log4j/Log4jXmlFormat). 
       [Increasing or decreasing the log level of a class or class hierarchy](/develop/tutorials/-/knowledge_base/7-0/adjusting-module-logging)
-      is best done outside of an Ext plugin.  
+      is best done outside of an Ext plugin, in @product@'s' UI or a Log4j XML
+      file in a module or the `osgi/log4j` folder. 
     - **Original file in Liferay:** `portal-impl/src/META-INF/portal-log4j.xml`
 - `ext-web/docroot/WEB-INF/portlet-ext.xml`
     - **Description:** Overrides the core portlets' declarations. It's most commonly

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -523,6 +523,14 @@ to the original file in @product@:
       configure specific data sources or swap the implementation of a default
       service with a custom one.
     - **Original file in @product@:** `portal-impl/src/META-INF/*-spring.xml`
+- `ext-impl/src/META-INF/portal-log4j-ext.xml`
+    - **Description:** Allows overriding the Log4j configuration. It can be used
+      to configure appenders for log file location, naming, and rotation. See
+      the
+      [Log4j XML Configuration Primer](https://wiki.apache.org/logging-log4j/Log4jXmlFormat). 
+      [Increasing or decreasing the log level of a class or class hierarchy](/develop/tutorials/-/knowledge_base/7-0/adjusting-module-logging)
+      is best done outside of an Ext plugin.  
+    - **Original file in Liferay:** `portal-impl/src/META-INF/portal-log4j.xml`
 - `ext-web/docroot/WEB-INF/portlet-ext.xml`
     - **Description:** Overrides the core portlets' declarations. It's most commonly
       used to change the init parameters or the roles specified. 

--- a/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
@@ -1,36 +1,33 @@
 # Adjusting Module Logging [](id=adjusting-module-logging)
 
 @product@ uses [Log4j](http://logging.apache.org/log4j/1.2/) logging
-services. You can configure logs for any module. Here's how: 
+services. Here are the ways to configure logging for module classes and class hierarchies.
 
-1.  Create the folder `[Liferay_Home]/osgi/log4j` if it's not there. 
+-   [DXP's UI]((/discover/portal/-/knowledge_base/7-0/server-administration#log-levels)
+-   Configure Log4j for multiple modules in a
+    `[anyModule]/src/main/resources/META-INF/module-log4j.xml` file.
+-   Configure Log4j for a specific module in a
+    `[Liferay Home]/osgi/log4j/[symbolicNameOfBundle]-log4j-ext.xml` file.
 
-2.  In the `log4j` folder, create a configuration file that follows this naming
-    convention:
+Here's an example Log4j XML configuration:
 
-        [Bundle-SymbolicName]-log4j-ext.xml
- 
-3.  In the configuration file, specify the module's Log4j configuration.
-    Here's an example configuration:
+    <?xml version="1.0"?>
+    <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+    <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+        <category name="org.foo">
+            <priority value="DEBUG" />
+        </category>
+    </log4j:configuration>
 
-        <?xml version="1.0"?>
-        <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-        <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-            <category name="org.foo.Bar">
-                <priority value="DEBUG" />
-            </category>
-        </log4j:configuration>
+Use `category` elements to specify each class or class hierarchy to log messages
+for. Set the `name` attribute to that class name or root package. The example
+category sets logging for the class hierarchy starting at package `org.foo`. Log
+messages at or above the `DEBUG` log level are printed for classes
+in `org.foo` and classes in packages starting with `org.foo`.
 
-    The remaining steps explain how to configure Log4j `category` elements.
- 
-4.  Specify `category` elements for each package or class to log messages. Set
-    the `name` attribute to that package or class name. The example category
-    sets logging for class `org.foo.Bar`.
-
-5.  Set each category's `priority` element to the log
-    [level](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html) 
-    (priority) you want.
-
+Set each category's `priority` element to the log
+[level](http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html)
+ (priority) you want.
     -   ALL
     -   DEBUG
     -   ERROR
@@ -40,7 +37,7 @@ services. You can configure logs for any module. Here's how:
     -   TRACE
     -   WARN
 
-The log messages are printed to Liferay log files in the `[Liferay_Home]/logs` folder.
+The log messages are printed to Liferay log files in `[Liferay_Home]/logs`.
 
 +$$$
 
@@ -50,6 +47,13 @@ configuration file name prefix matches the module's symbolic name. If you have
 Bnd installed, output from command `bnd print [path-to-bundle]` includes the
 module’s symbolic name ([Here](https://github.com/bndtools/bnd/wiki/Install-bnd-on-the-command-line)
 are instructions for installing Bnd for the command line).
+
+$$$
+
++$$$
+
+Note: A Log4j configuration's appenders control log file location, naming, and rotation.
+[To override advanced Log4j options such as DXP's appenders, use an Ext plugin](/develop/tutorials/-/knowledge_base/7-0/advanced-customization-with-ext-plugins#using-advanced-configuration-files). 
 
 $$$
 

--- a/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
@@ -3,7 +3,7 @@
 @product@ uses [Log4j](http://logging.apache.org/log4j/1.2/) logging
 services. Here are the ways to configure logging for module classes and class hierarchies.
 
--   [DXP's UI]((/discover/portal/-/knowledge_base/7-0/server-administration#log-levels)
+-   [@product@'s UI]((/discover/portal/-/knowledge_base/7-0/server-administration#log-levels)
 -   Configure Log4j for multiple modules in a
     `[anyModule]/src/main/resources/META-INF/module-log4j.xml` file.
 -   Configure Log4j for a specific module in a
@@ -53,7 +53,7 @@ $$$
 +$$$
 
 Note: A Log4j configuration's appenders control log file location, naming, and rotation.
-[To override advanced Log4j options such as DXP's appenders, use an Ext plugin](/develop/tutorials/-/knowledge_base/7-0/advanced-customization-with-ext-plugins#using-advanced-configuration-files). 
+[To override advanced Log4j options such as @product@'s log appenders, use an Ext plugin](/develop/tutorials/-/knowledge_base/7-0/advanced-customization-with-ext-plugins#using-advanced-configuration-files). 
 
 $$$
 

--- a/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
@@ -8,6 +8,8 @@ services. Here are the ways to configure logging for module classes and class hi
     `[anyModule]/src/main/resources/META-INF/module-log4j.xml` file.
 -   Configure Log4j for a specific module in a
     `[Liferay Home]/osgi/log4j/[symbolicNameOfBundle]-log4j-ext.xml` file.
+-   Configure Log4j for an OSGi fragment host module in a
+    `/META-INF/module-log4j-ext.xml` file
 
 Here's an example Log4j XML configuration:
 


### PR DESCRIPTION
These changes explain how to use an Ext plugin to customize Portal's Log4j configuration and mention using Portal's UI and a module's module-log4j.xml to customize categories and log levels.

The one I'm not familiar with is using a module-log4j.xml in a module to affect any number of categories across modules. Nathan Shaw mentioned that one in https://issues.liferay.com/browse/LRDOCS-3628.

https://issues.liferay.com/browse/LRDOCS-4115
https://issues.liferay.com/browse/LRDOCS-3628